### PR TITLE
Proto toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
 # Test output information
 test --test_output=errors --test_summary=detailed
 
+# Allow resolving protoc from a pre-built toolchain
+common --incompatible_enable_proto_toolchain_resolution
+
 # Don't report when the root module's lower bound for a dependency happens to be less than the resolved version.
 # This is expected and should NOT prompt an engineer to update our lower bound to match.
 # WARNING: For repository 'aspect_bazel_lib', the root module requires module version aspect_bazel_lib@1.30.2,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,15 +6,20 @@ bazel_dep(name = "aspect_rules_js", version = "1.32.6")
 bazel_dep(name = "aspect_rules_ts", version = "2.0.0")
 bazel_dep(name = "aspect_rules_swc", version = "1.1.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
-bazel_dep(name = "protobuf", version = "21.7")
 bazel_dep(name = "gazelle", version = "0.32.0")
 bazel_dep(name = "rules_apple", version = "3.0.0")
 bazel_dep(name = "rules_go", version = "0.41.0")
+bazel_dep(name = "gazelle", version = "0.32.0")
+bazel_dep(name = "rules_proto", version = "6.0.0")
+bazel_dep(name = "rules_java", version = "7.4.0")
 bazel_dep(name = "rules_jvm_external", version = "4.5")
 bazel_dep(name = "rules_python", version = "0.27.1")
 bazel_dep(name = "rules_swift", version = "1.12.0")
 bazel_dep(name = "rules_swift_package_manager", version = "0.12.0")
 bazel_dep(name = "rules_xcodeproj", version = "1.11.0")
+bazel_dep(name = "toolchains_protoc", version = "0.2.4")
+
+register_toolchains("//tools/toolchains:all")
 
 # Python
 # https://github.com/bazelbuild/rules_python/tree/main/examples/bzlmod

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,24 +3,44 @@
 bazel_dep(name = "apple_support", version = "1.11.1")
 bazel_dep(name = "aspect_bazel_lib", version = "1.35.0")
 bazel_dep(name = "aspect_rules_js", version = "1.32.6")
-bazel_dep(name = "aspect_rules_ts", version = "2.0.0")
 bazel_dep(name = "aspect_rules_swc", version = "1.1.0")
+bazel_dep(name = "aspect_rules_ts", version = "2.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "gazelle", version = "0.32.0")
 bazel_dep(name = "rules_apple", version = "3.0.0")
 bazel_dep(name = "rules_go", version = "0.41.0")
-bazel_dep(name = "gazelle", version = "0.32.0")
-bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "rules_java", version = "7.4.0")
 bazel_dep(name = "rules_jvm_external", version = "4.5")
+bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "rules_python", version = "0.27.1")
 bazel_dep(name = "rules_swift", version = "1.12.0")
 bazel_dep(name = "rules_swift_package_manager", version = "0.12.0")
 bazel_dep(name = "rules_xcodeproj", version = "1.11.0")
-bazel_dep(name = "toolchains_protoc", version = "0.2.4")
+bazel_dep(name = "toolchains_protoc", version = "0.3.1")
 
+# Demonstrate that you can copy "arbitrary fetches" like http_archive from the WORKSPACE file
+http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+
+http_jar(
+    name = "protobuf-java",
+    integrity = "sha256-eYx59sn8aFnMdqpUdCKKrSUIIUOOEATa00iA1TqnRfk=",
+    urls = ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/4.27.1/protobuf-java-4.27.1.jar"],
+)
+
+#########################
+# Protobuf and gRPC
+# https://github.com/aspect-build/toolchains_protoc
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
+protoc.toolchain(
+    google_protobuf = "com_google_protobuf",
+    version = "LATEST",
+)
+use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
+
+register_toolchains("@toolchains_protoc_hub//:all")
 register_toolchains("//tools/toolchains:all")
 
+#########################
 # Python
 # https://github.com/bazelbuild/rules_python/tree/main/examples/bzlmod
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
@@ -36,6 +56,7 @@ pip.parse(
 )
 use_repo(pip, "pip")
 
+#########################
 # Java and other JVM languages:
 # https://github.com/bazelbuild/rules_jvm_external/blob/master/examples/bzlmod/MODULE.bazel
 # https://github.com/bazelbuild/rules_jvm_external#pinning-artifacts-and-integration-with-bazels-downloader
@@ -50,6 +71,7 @@ use_repo(
     "unpinned_maven",
 )
 
+#########################
 # JavaScript and TypeScript
 # https://github.com/aspect-build/rules_js/tree/main/e2e/bzlmod
 # https://github.com/aspect-build/rules_ts/tree/main/e2e/bzlmod
@@ -74,6 +96,7 @@ rules_ts_ext = use_extension(
 rules_ts_ext.deps()
 use_repo(rules_ts_ext, "npm_typescript")
 
+#########################
 # Go
 # See https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
@@ -101,7 +124,8 @@ use_repo(
     "com_github_grpc_grpc_swift",
 )
 
-# swift_deps START
+#########################
+# Swift
 swift_deps = use_extension(
     "@rules_swift_package_manager//:extensions.bzl",
     "swift_deps",
@@ -113,4 +137,3 @@ use_repo(
     swift_deps,
     "swiftpkg_swifterswift",
 )
-# swift_deps END

--- a/tools/toolchains/BUILD.bazel
+++ b/tools/toolchains/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
+
+proto_lang_toolchain(
+    name = "protoc_java_toolchain",
+    command_line = "--java_out=%s",
+    progress_message = "Generating Java proto_library %{label}",
+    runtime = "@protobuf-java//jar",
+    toolchain_type = "@rules_java//java/proto:toolchain_type",
+)


### PR DESCRIPTION
Prevents engineers needing a functional local C++ compilation toolchain on their machine. And saves a bunch of time in builds, and avoids protobuf gcc warnings from poking out on user's terminals.
